### PR TITLE
Readability pass on amortization core modules

### DIFF
--- a/amortization/amortize.py
+++ b/amortization/amortize.py
@@ -12,7 +12,7 @@ def main() -> None:  # pragma: no cover
     from tabulate import tabulate
 
     class ConvertFrequency(argparse.Action):
-        def __call__(self, parser: Any, namespace: Any, values: Any, option_string: Any = None) -> None:
+        def __call__(self, parser: Any, namespace: Any, values: Any, _option_string: Any = None) -> None:
             setattr(namespace, self.dest, PaymentFrequency[values.upper()])
 
     parser = argparse.ArgumentParser(

--- a/amortization/period.py
+++ b/amortization/period.py
@@ -37,4 +37,4 @@ def calculate_amortization_period(
     min_amount = adjusted_interest * principal
     if amount <= min_amount:
         raise ValueError(f"amount must exceed the first period's interest of {min_amount:.2f}")
-    return round(log(amount / (amount - adjusted_interest * principal), 1 + adjusted_interest))
+    return round(log(amount / (amount - min_amount), 1 + adjusted_interest))


### PR DESCRIPTION
Small readability fixes in the amortization CLI and period calculator — reusing an assigned local and silencing a vulture false-positive on the argparse action signature.

## Summary

**Repo health:** 84/100

ShipGate reported **~2 refactoring opportunities** (strict refactor scan), **~6 lint findings** in the full check suite. Security, duplication, and maintainability dimensions are summarized below; see the linked gist for raw captures.

### File hotspots

| File | Issues | Action |
| --- | ---: | --- |
| `tests/test_amortization.py` | ~2 (1 lint, 1 refactor) | address unresolved-import; address no-loop-in-tests |
| `pr-body.md` | ~2 lint | address undocumented-acronym |
| `amortization/amortize.py` | ~1 lint | address unresolved-import |
| `amortization/period.py` | ~1 refactor | address use-assigned-variable |

## What you are doing right

- **Security:** No high-severity bandit hits or secrets flagged by gitleaks/semgrep in the scanned scope.
- **Dependencies:** pip-audit and deptry reported no critical vulnerabilities or unused dependency issues.
- **Dead code:** vulture/deadcode found few or no unused symbols in production modules.
- **Duplication:** jscpd duplication is low for the scanned tree.
- **Maintainability:** radon complexity/maintainability gates are mostly clean.
- **Refactoring:** Strict refactor scan found only ~2 opportunities — structure is relatively stable.

## What you could improve

- **Hotspot:** `tests/test_amortization.py` concentrates the most findings — start there for incremental cleanup.

## Changes

| Pass | Files | Fixes / rules | Manual? |
| --- | ---: | --- | --- |
| `shipgate format` | 0 | completed | no |
| `tests` | 0 | make test | no |
| **Total** | **0** | *See autofix.log for details* | — |

---
*We're testing [ShipGate](https://github.com/inquilabee/shipgate) on real-world projects to learn whether it works well in practice. This review summary was generated from ShipGate check output and AI-assisted analysis. Feedback on the findings or approach is welcome and appreciated — [docs](https://inquilabee.github.io/shipgate/).*

*Full ShipGate findings:* [review gist](All outreach exclude patterns already present in .git/info/exclude
PASS: git check-ignore honors outreach exclude patterns
https://gist.github.com/inquilabee/7c79f6ae75378de68dc903dd9d2f8e43)
